### PR TITLE
Depends on specific automaton version

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "colors": "~0.6.0",
     "mout": "~0.6.0",
     "dot": "~1.0.0",
-    "automaton": "~0.2.0",
+    "automaton": "0.2.0-rc.3",
     "nopt": "~2.0.0",
     "update-notifier": "~0.1.2"
   },


### PR DESCRIPTION
npm 2.0 changed the `semver` module, which means that it can't find RCs anymore.

/cc @satazor 
